### PR TITLE
pc/rb - changes to fix a problem with Gradescope autograder

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/config/SpringFoxConfig.java
@@ -10,20 +10,94 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.core.env.Environment;
+
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
+import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.util.StringUtils;
+
 /**
  * Configuration for Swagger, a package that provides documentation
  * for REST API endpoints.
- * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ * 
+ * @see <a href=
+ *      "https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
  */
 
 @Configuration
-public class SpringFoxConfig {                                    
+public class SpringFoxConfig {
+
+    /*
+     * This is a bean that defines the "docket" for Swagger. It is a
+     * configuration object that tells Swagger what to document.
+     */
     @Bean
-    public Docket api() { 
-        return new Docket(DocumentationType.SWAGGER_2)  
-          .select()                                  
-          .apis(RequestHandlerSelectors.any())  
-          .paths(Predicate.not(PathSelectors.regex("/error.*")))//<6>, regex must be in double quotes.            
-          .build();                                           
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(Predicate.not(PathSelectors.regex("/error.*")))// <6>, regex must be in double quotes.
+                .build();
+    }
+
+    /**
+     * This is a workaround for a bug in SpringFox
+     * 
+     * @see <a href=
+     *      "https://stackoverflow.com/a/70892119">https://stackoverflow.com/a/70892119</a>
+     *
+     * 
+     * @param webEndpointsSupplier
+     * @param servletEndpointsSupplier
+     * @param controllerEndpointsSupplier
+     * @param endpointMediaTypes
+     * @param corsProperties
+     * @param webEndpointProperties
+     * @param environment
+     * @return
+     */
+
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(WebEndpointsSupplier webEndpointsSupplier,
+            ServletEndpointsSupplier servletEndpointsSupplier, ControllerEndpointsSupplier controllerEndpointsSupplier,
+            EndpointMediaTypes endpointMediaTypes, CorsEndpointProperties corsProperties,
+            WebEndpointProperties webEndpointProperties, Environment environment) {
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList<ExposableEndpoint<?>>();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment,
+                basePath);
+        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
+                corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath),
+                shouldRegisterLinksMapping);
+    }
+
+    /*
+     * This is a workaround for a bug in SpringFox
+     * See https://stackoverflow.com/a/70892119
+     */
+
+    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment,
+            String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath)
+                || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=${PORT:8080}
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER


### PR DESCRIPTION
In this PR, we address a problem that was causing the starter code for team01 to fail on Gradescopes autograder team01 with the following error:

java.lang.IllegalStateException: Failed to load ApplicationContext Caused by: org.springframework.context.ApplicationContextException: Failed to start bean documentationPluginsBootstrapper; nested exception is java.lang.NullPointerException: Cannot invoke "org.springframework.web.servlet.mvc.condition.PatternsRequestCondition.getPatterns()" because "this.condition" is null Caused by: java.lang.NullPointerException: Cannot invoke "org.springframework.web.servlet.mvc.condition.PatternsRequestCondition.getPatterns()" because "this.condition" is null

The fix was found by Prof. Conrad and tested by @briggsrr, and comes from this stack overflow answer:

https://stackoverflow.com/a/70892119

It consists of 
* Adding a property in `application.properties`
* Adding a configuration bean in the SpringFoxConfig.java class